### PR TITLE
fix claim form z-index

### DIFF
--- a/src/containers/Form/index.tsx
+++ b/src/containers/Form/index.tsx
@@ -7,7 +7,7 @@ const FormPage = ({ toggleSnackbar, setSnackbarMessage, setLoading }: IHomeProps
   return (
     <>
       <BackgroundImages />
-      <Paper sx={{ zIndex: 20, my: 10, marginTop: { xs: 20, md: 10 } }}>
+      <Paper sx={{ zIndex: 1, my: 10, marginTop: { xs: 20, md: 10 } }}>
         <Form toggleSnackbar={toggleSnackbar} setSnackbarMessage={setSnackbarMessage} setLoading={setLoading} />
       </Paper>
     </>


### PR DESCRIPTION
# There was a bug with z-index of add claim form.
![image](https://github.com/Whats-Cookin/trust_claim/assets/106309885/dffdd5ea-7ffe-4134-aaa4-e4ac05823e03)


