### PR TITLE
fix[frontend]: Update Display Text for Claim and HowKnown

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -220,8 +220,22 @@ export const Form = ({
   }
   let titleText = 'Enter a Claim'
 
+  const displayHowKnownText = {
+    first_hand: 'First Hand',
+    second_hand: 'Second Hand',
+    website: 'Website',
+    physical_document: 'Physical Document'
+  } as any
+
+  const displayClaimText = {
+    related_to: 'Related To',
+    impact: 'Impact',
+    rated: 'Rated',
+    report: 'Report'
+  } as any
+
   if (selectedClaim) {
-    titleText = selectedClaim.entType === 'CLAIM' ? 'do you want to validate ?' : 'what do you have to say about'
+    titleText = selectedClaim.entType === 'CLAIM' ? 'Do you want to validate ?' : 'What do you have to say about'
   }
   const theme = useTheme()
   return (
@@ -341,7 +355,8 @@ export const Form = ({
                     key={claimText}
                   >
                     <Tooltip title={tooltips.claim[index]} placement='right' arrow>
-                      <Box sx={{ width: '100%', height: '100%' }}>{claimText}</Box>
+                      {/* ['rated', 'impact', 'report', 'related_to'] */}
+                      <Box sx={{ width: '100%', height: '100%' }}>{displayClaimText[claimText] || claimText}</Box>
                     </Tooltip>
                   </MenuItem>
                 ))}
@@ -398,7 +413,9 @@ export const Form = ({
                     key={howKnownText}
                   >
                     <Tooltip title={tooltips.howKnown[index]} placement='right' arrow>
-                      <Box sx={{ width: '100%', height: '100%' }}>{howKnownText}</Box>
+                      <Box sx={{ width: '100%', height: '100%' }}>
+                        {displayHowKnownText[howKnownText] || howKnownText}
+                      </Box>
                     </Tooltip>
                   </MenuItem>
                 ))}

--- a/src/containers/feedOfClaim/index.tsx
+++ b/src/containers/feedOfClaim/index.tsx
@@ -547,7 +547,7 @@ const FeedClaim: React.FC<IHomeProps> = ({ toggleTheme, isDarkMode }) => {
             </Box>
           ) : (
             <Box sx={{ textAlign: 'center', mt: '20px' }}>
-              <Typography variant='h6'>No results found for "{searchTerm}"</Typography>
+              <Typography variant='h6'>No results found{searchTerm ? ` for ${searchTerm}` : '.'}</Typography>
             </Box>
           )}
         </>


### PR DESCRIPTION
this is just a small PR about how the text is displayed 
from this
![Screenshot from 2024-07-07 22-43-39](https://github.com/Whats-Cookin/trust_claim/assets/120126262/1127e2eb-96cc-4496-a55b-5116135ad9a7)
to this:
![Screenshot from 2024-07-07 22-43-56](https://github.com/Whats-Cookin/trust_claim/assets/120126262/cd378e6a-9d0a-420e-9740-90bb68d96ea0)

also for howKnown


I know it is not a big deal but I thought it was not good to have it as in the database