### PR TITLE
feat(claim_form): if creation took more than 1 sec assume that it was…

### DIFF
--- a/src/utils/promise.utils.ts
+++ b/src/utils/promise.utils.ts
@@ -1,0 +1,17 @@
+export class PromiseTimeoutError extends Error {
+  constructor() {
+    super('Promise Timed-out')
+    this.name = 'PromiseTimeoutError'
+  }
+}
+
+function rejectAfter(ms: number) {
+  return new Promise((_, reject) => setTimeout(() => reject(new PromiseTimeoutError()), ms))
+}
+
+export async function timeoutPromise<T extends Promise<K>, K = Awaited<T>>(
+  promise: T,
+  timeoutAfter: number
+): Promise<K> {
+  return Promise.race([promise, rejectAfter(timeoutAfter)]) as Promise<K>
+}


### PR DESCRIPTION
… created

- If creating claim request took more than 1 second assume that is was created and redirect to the feed anyway.
- Create promise utilities.