### PR TITLE
fix(graph): on right clicking the edge, pass the sorce claim, not the…

### DIFF
--- a/src/containers/Search/index.tsx
+++ b/src/containers/Search/index.tsx
@@ -135,7 +135,13 @@ const Search = (homeProps: IHomeProps) => {
   const handleMouseRightClick = (event: any) => {
     event.preventDefault()
     const claim = event.target
-    const currentClaim = claim.data('raw')
+    let currentClaim = claim.data('raw')
+
+    const isEdge = !!currentClaim.claim
+
+    if (isEdge) {
+      currentClaim = claim.connectedNodes()[0].data('raw')
+    }
 
     if (currentClaim) {
       setSelectedClaim(currentClaim)


### PR DESCRIPTION
… edge

## Description

On right-clicking an edge on the graph, show the validation form with the claim details prefilled.

NOTE: This will fill the form with the source node data.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Please provide a brief summary of the results after testing the changes in this PR.

## 7- screenshots

![screenshot_2024-09-11-02-00-23](https://github.com/user-attachments/assets/6020d7c8-9c44-4848-8c73-dc504d18b3be)
