### PR TITLE
fix(claim_views): navigate to graph with the name instead of the url

### DIFF
--- a/src/components/Validate/index.tsx
+++ b/src/components/Validate/index.tsx
@@ -86,7 +86,6 @@ const Validate = ({ toggleSnackbar, setSnackbarMessage }: IHomeProps) => {
       try {
         setLoading(true)
         const res = await axios.get(`/api/claim/${number}`)
-        console.log(res.data)
 
         if (res.data.subject) setSubjectValue(res.data.subject)
         if (res.data.statement) setStatementValue(res.data.statement)

--- a/src/containers/feedOfClaim/index.tsx
+++ b/src/containers/feedOfClaim/index.tsx
@@ -193,11 +193,11 @@ const FeedClaim: React.FC<IHomeProps> = () => {
     })
   }
 
-  const handleschema = async (nodeUri: string) => {
-    const domain = nodeUri.replace(/^https?:\/\//, '').replace(/\/$/, '')
+  const handleschema = async (claim: ImportedClaim) => {
+    console.log(claim)
     navigate({
       pathname: '/search',
-      search: `?query=${domain}`
+      search: `?query=${claim.name}`
     })
   }
 
@@ -352,7 +352,7 @@ const FeedClaim: React.FC<IHomeProps> = () => {
                           </Link>
                           <Button
                             startIcon={<ShareOutlinedIcon />}
-                            onClick={() => handleschema(claim.link)}
+                            onClick={() => handleschema(claim)}
                             variant='text'
                             sx={{
                               fontSize: isMediumScreen ? '8px' : '12px',


### PR DESCRIPTION
## Description

Setup the correct query to show on the graph page; use the title instead of the url

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Please provide a brief summary of the results after testing the changes in this PR.

## 7- screenshots ?

![image](https://github.com/user-attachments/assets/0488753a-452a-48a8-b10e-0bae775b21c9)
