### PR TITLE
decrease MainContainer top margin for both mobile and desktop

### DIFF
--- a/src/components/MainContainer/index.tsx
+++ b/src/components/MainContainer/index.tsx
@@ -19,7 +19,7 @@ const MainContainer: React.FC<Props> = ({ children, flexRowOnDesktop, sx }) => {
         justifyContent: flexRowOnDesktop && !isMobile ? 'flex-end' : 'center',
         height: 'auto',
 
-        mt: '64px',
+        mt: isMobile ? '8px' : '16px',
         mb: isMobile ? '77px' : '28px',
 
         paddingTop: isMobile ? '20px' : '41px',


### PR DESCRIPTION
## Description

Decrease margin-top value to 8px for Mobile and 16px for Desktop

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [x] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Improve the looks of claims feed

## 7- screenshots ?

Please provide screenshots of the results after testing the changes in this PR.
