### PR TITLE
fix: reflect stale auth state in UI when refresh token expires

### DIFF
--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -19,14 +19,32 @@ export const handleAuthSuccess = (authData: AuthState) => {
   window.dispatchEvent(new Event(AUTH_STATE_CHANGED_EVENT))
 }
 
+const isJwtExpired = (token: string): boolean => {
+  try {
+    const part = token.split('.')[1]
+    if (!part) return false
+    const normalized = part.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+    const payload = JSON.parse(atob(padded))
+    if (typeof payload.exp !== 'number') return false
+    return Date.now() >= payload.exp * 1000
+  } catch {
+    return false
+  }
+}
+
 export const checkAuth = () => {
   const accessToken = localStorage.getItem('accessToken')
   const refreshToken = localStorage.getItem('refreshToken')
   const ethAddress = localStorage.getItem('ethAddress') || undefined
   const did = localStorage.getItem('did')
 
-  // JWT auth is primary authentication method
-  if (accessToken && refreshToken) return true
+  // JWT auth is primary authentication method.
+  // Session lives as long as the refresh token; access token is renewed by the axios interceptor.
+  if (accessToken && refreshToken) {
+    if (isJwtExpired(refreshToken)) return false
+    return true
+  }
 
   // Support legacy DID-only auth
   if (did && ethAddress) return true
@@ -61,6 +79,7 @@ export const clearAuth = () => {
   localStorage.removeItem('refreshToken')
   localStorage.removeItem('ethAddress')
   localStorage.removeItem('did')
+  window.dispatchEvent(new Event(AUTH_STATE_CHANGED_EVENT))
 }
 
 // Ceramic-related functions removed


### PR DESCRIPTION
Two gaps left the create-claim "+" visible (and /claim accessible) after the session was dead server-side:

1. clearAuth() didn't dispatch AUTH_STATE_CHANGED_EVENT, so React state stayed authenticated until the next route change — even after the axios interceptor wiped tokens on a refresh-failure 401.
2. checkAuth() only verified token presence in localStorage, not freshness — expired refresh tokens still read as authenticated on first paint.

clearAuth now fires the event so the UI re-renders immediately, and checkAuth decodes the refresh token's exp claim and treats expired tokens as logged out. With both, the Login button shows and the "+" hides as soon as the session is no longer usable.

## Description

Please provide a brief summary of the changes in this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Please provide a brief summary of the results after testing the changes in this PR.

## 7- screenshots ?

Please provide screenshots of the results after testing the changes in this PR.
